### PR TITLE
Bugfix (sc-286472): Fix contract name on instantiate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "funding-trading-bridge-smart-contract"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funding-trading-bridge-smart-contract"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Jake Schwartz <jschwartz@figure.com>"]
 edition = "2021"
 

--- a/src/instantiate/instantiate_contract.rs
+++ b/src/instantiate/instantiate_contract.rs
@@ -30,7 +30,12 @@ pub fn instantiate_contract(
         .add_attribute("trading_marker_name", &msg.trading_marker.name);
     if let Some(name) = msg.name_to_bind {
         response = response
-            .add_message(msg_bind_name(&name, env.contract.address, true)?)
+            .add_message(msg_bind_name(
+                &deps.as_ref(),
+                &name,
+                env.contract.address,
+                true,
+            )?)
             .add_attribute("contract_bound_with_name", name)
     }
     response.to_ok()


### PR DESCRIPTION
# Description
When the contract is instantiated, the name binding fails because you have to populate the address field of the parent record for some reason... This resolves it and mods the test to verify that it works.