### PR TITLE
Bugfixes (sc-314182): Figure audit requested changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "semver",
  "serde",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -853,6 +854,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ semver = "=1.0.16"
 serde = { version = "=1.0.190", default-features = false, features = ["derive"] }
 thiserror = "=1.0.50"
 prost = { version = "=0.11.9", default-features = false }
+uuid = "1.10.0"
 
 [dev-dependencies]
 cosmwasm-schema = "=1.4.1"

--- a/src/util/provenance_utils.rs
+++ b/src/util/provenance_utils.rs
@@ -93,9 +93,7 @@ pub fn check_account_has_all_attributes<S: Into<String>>(
     let mut remaining_attributes = attributes.to_vec();
     while !remaining_attributes.is_empty() {
         for attr in latest_response.attributes.iter() {
-            if remaining_attributes.contains(&attr.name) {
-                remaining_attributes.retain(|name| name != &attr.name);
-            }
+            remaining_attributes.retain(|name| name != &attr.name);
         }
         if !remaining_attributes.is_empty() {
             if latest_response.pagination.is_some()

--- a/src/util/validation_utils.rs
+++ b/src/util/validation_utils.rs
@@ -28,6 +28,9 @@ pub fn check_funds_are_empty(info: &MessageInfo) -> Result<(), ContractError> {
 /// - Each segment must be between 2 and 32 characters.
 /// - Each segment must be alphanumeric.
 /// - Each segment can have a single '-' character, or be a valid uuid if it includes '-' characters.
+///
+/// Referenced code (at time of writing): https://github.com/provenance-io/provenance/blob/main/x/name/types/name.go#L82
+/// Referenced documentation describing these requirements (at time of writing): https://github.com/provenance-io/provenance/blob/main/x/name/spec/01_concepts.md
 pub fn validate_attribute_name<S: Into<String>>(name: S) -> Result<(), ContractError> {
     let name = name.into();
     let name_parts = name.split('.').collect::<Vec<&str>>();
@@ -49,8 +52,11 @@ pub fn validate_attribute_name<S: Into<String>>(name: S) -> Result<(), ContractE
         .to_err();
     }
     if name_parts.iter().any(|part| {
+        // A segment is immediately valid if it conforms as a valid UUID
         Uuid::parse_str(part).is_err()
+            // A segment can include only one dash
             && (part.chars().filter(|c| c == &'-').count() > 1
+            // A segment must be fully alphanumeric, barring the single dash allowance
                 || !part
                     .chars()
                     .filter(|c| c != &'-')

--- a/src/util/validation_utils.rs
+++ b/src/util/validation_utils.rs
@@ -1,6 +1,7 @@
 use crate::types::error::ContractError;
 use cosmwasm_std::MessageInfo;
 use result_extensions::ResultExtensions;
+use uuid::Uuid;
 
 /// Verifies that the funds sent into the message info are empty, ensuring that the contract has not
 /// received any funding when invoked.
@@ -20,9 +21,54 @@ pub fn check_funds_are_empty(info: &MessageInfo) -> Result<(), ContractError> {
     }
 }
 
+/// Verifies that the provided string is a valid attribute name for the Provenance Blockchain,
+/// following their rules:
+/// - The attribute must not be empty.
+/// - The attribute must have at maximum 16 segments, separated by periods.
+/// - Each segment must be between 2 and 32 characters.
+/// - Each segment must be alphanumeric.
+/// - Each segment can have a single '-' character, or be a valid uuid if it includes '-' characters.
+pub fn validate_attribute_name<S: Into<String>>(name: S) -> Result<(), ContractError> {
+    let name = name.into();
+    let name_parts = name.split('.').collect::<Vec<&str>>();
+    if name_parts.len() > 16 {
+        return ContractError::InvalidFormatError {
+            message: format!("Attribute name {name} has too many segments"),
+        }
+        .to_err();
+    }
+    if name_parts
+        .iter()
+        .any(|part| !(2usize..33usize).contains(&part.len()))
+    {
+        return ContractError::InvalidFormatError {
+            message: format!(
+                "Attribute name {name} contains at least one segment with an incorrect size"
+            ),
+        }
+        .to_err();
+    }
+    if name_parts.iter().any(|part| {
+        Uuid::parse_str(part).is_err()
+            && (part.chars().filter(|c| c == &'-').count() > 1
+                || !part
+                    .chars()
+                    .filter(|c| c != &'-')
+                    .all(char::is_alphanumeric))
+    }) {
+        return ContractError::InvalidFormatError {
+            message: format!(
+                "Attribute name {name} contains at least one segment that is not a uuid, has more than one dash character, or violates alphanumeric values"
+            ),
+        }
+        .to_err();
+    }
+    ().to_ok()
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::util::validation_utils::check_funds_are_empty;
+    use crate::util::validation_utils::{check_funds_are_empty, validate_attribute_name};
     use cosmwasm_std::testing::mock_info;
     use cosmwasm_std::{coin, coins};
 
@@ -37,5 +83,66 @@ mod tests {
             &[coin(1, "denomA"), coin(1, "denomB")],
         ))
         .expect_err("multiple coins should produce an error");
+    }
+
+    #[test]
+    fn test_valid_attribute_name_use_cases() {
+        // Invalid Cases:
+        // Empty string is not allowed
+        assert_attribute_invalid("");
+        // 16 segments at max
+        assert_attribute_invalid("aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa");
+        // Empty segment is not allowed
+        assert_attribute_invalid("part.");
+        assert_attribute_invalid(".part");
+        // Each segment must be between 2 and 32 characters
+        assert_attribute_invalid("a");
+        assert_attribute_invalid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_attribute_invalid("validthing.b");
+        // Each segment must be only alphanumeric
+        assert_attribute_invalid("properformat.iµhñuo˜¨ñ:");
+        assert_attribute_invalid("hellothere.😄kjdsfijds.93ksdjlfd008");
+        // No whitespace in segments
+        assert_attribute_invalid("normalish.butthen.itgot weird");
+        assert_attribute_invalid("aw jeez.rick");
+        // Includes too many dashes
+        assert_attribute_invalid("--.uu.sdfsd");
+        assert_attribute_invalid("a-b.haha-asdddd-djdjdj");
+
+        // Valid Cases:
+        // Single segment
+        assert_attribute_valid("onename");
+        // Max segments
+        assert_attribute_valid("aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa.aa");
+        // Character limits
+        assert_attribute_valid("aa");
+        assert_attribute_valid("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_attribute_valid("aa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        // Alphanumeric
+        assert_attribute_valid("1234.jjjjdijdjidJAUSUD.902NJSAhdsjs");
+        // UUID segments
+        assert_attribute_invalid("9372bae6-3f0a-11ef-b0d9-b3a1f5fefa08.aa");
+        // Dash segments
+        assert_attribute_valid("this-is.a-valid.name");
+    }
+
+    fn assert_attribute_valid<S: Into<String>>(attribute_name: S) {
+        let attribute_name = attribute_name.into();
+        match validate_attribute_name(&attribute_name) {
+            Ok(()) => {}
+            Err(e) => {
+                panic!(
+                    "Expected attribute {attribute_name} to be valid, but got: {:?}",
+                    e
+                )
+            }
+        };
+    }
+
+    fn assert_attribute_invalid<S: Into<String>>(attribute_name: S) {
+        let attribute_name = attribute_name.into();
+        validate_attribute_name(&attribute_name).expect_err(&format!(
+            "expected attribute {attribute_name} to be invalid"
+        ));
     }
 }

--- a/src/util/validation_utils.rs
+++ b/src/util/validation_utils.rs
@@ -31,6 +31,10 @@ pub fn check_funds_are_empty(info: &MessageInfo) -> Result<(), ContractError> {
 ///
 /// Referenced code (at time of writing): https://github.com/provenance-io/provenance/blob/main/x/name/types/name.go#L82
 /// Referenced documentation describing these requirements (at time of writing): https://github.com/provenance-io/provenance/blob/main/x/name/spec/01_concepts.md
+///
+/// # Parameters
+///
+/// * `name` The fully-qualified attribute name.  Ex: name-thing.name
 pub fn validate_attribute_name<S: Into<String>>(name: S) -> Result<(), ContractError> {
     let name = name.into();
     let name_parts = name.split('.').collect::<Vec<&str>>();


### PR DESCRIPTION
# Description
The Figure audit revealed the need for the following changes.

## Changes
- During fund/withdraw execute flows, the amount sent is the amount validated. However, after discerning how much funds will be taken from the sender, the initial value specified may not be fully utilized. Ex: The user sends that they want to convert 150 coin, but after converting to the other denom, there will be 50 leftover coin, so the user will only have 100 coin removed from their account. The contract will always validate that the user holds 150 coin and reject calls from users that don't already have that amount, but the user technically only needs 100 coin in this circumstance.
- In the provenance_utils.rs file on line 97, the code calls retain after doing a contains check. This is redundant. The retain function should remain and the contains check can be removed.
- Validation for attribute names input to the contract should be done to ensure that they are in valid provenance format. This will require a little research on Provenance's attribute name spec.